### PR TITLE
feat: verify msg.sender to be the owner when calling registerPoh

### DIFF
--- a/packages/l2-contracts/test/ethregistrar/TestEthRegistrarController.js
+++ b/packages/l2-contracts/test/ethregistrar/TestEthRegistrarController.js
@@ -273,7 +273,7 @@ contract('ETHRegistrarController', function () {
     const name = 'pohname'
     const duration = 28 * 24 * 60 * 60 // 28 days in seconds
     const secret = ethers.utils.formatBytes32String('secret')
-    const human = signers[1].address
+    const human = signers[0].address
     const signature = ethers.utils.hexlify(ethers.utils.randomBytes(65)) // Mock signature
 
     // Generate a commitment for the registration


### PR DESCRIPTION
We need to check for the sender when calling registerPoh because otherwise if someone has access to the signature of another address, that person can be use it to lock someone's address to an unwanted domain.