### PR TITLE
audit 4.2 Unbounded Gas Consumption in the while in LineaProofHelper

### DIFF
--- a/packages/l1-contracts/contracts/linea-verifier/LineaProofHelper.sol
+++ b/packages/l1-contracts/contracts/linea-verifier/LineaProofHelper.sol
@@ -84,54 +84,36 @@ library LineaProofHelper {
         if (!storageProofs[proofIdx].initialized) {
             return ("", proofIdx++);
         }
-        bytes32 firstValue = storageProofs[proofIdx].proof.value;
         verifyStorageProof(
             account,
             storageProofs[proofIdx].leafIndex,
             storageProofs[proofIdx].proof.proofRelatedNodes,
-            firstValue,
+            storageProofs[proofIdx].proof.value,
             bytes32(slot)
         );
-        uint256 firstValueUint = uint256(firstValue);
-        proofIdx++;
-        if (firstValueUint & 0x01 == 0x01) {
+        uint256 firstValue = uint256(storageProofs[proofIdx++].proof.value);
+        if (firstValue & 0x01 == 0x01) {
             // Long value: first slot is `length * 2 + 1`, following slots are data.
-            uint256 length = (firstValueUint - 1) / 2;
-            value = "";
             slot = uint256(keccak256(abi.encodePacked(slot)));
-            while (length > 0) {
+            value = new bytes(firstValue >> 1);
+            uint256 off;
+            while (off < value.length) {
                 verifyStorageProof(
                     account,
                     storageProofs[proofIdx].leafIndex,
                     storageProofs[proofIdx].proof.proofRelatedNodes,
                     storageProofs[proofIdx].proof.value,
-                    bytes32(slot)
+                    bytes32(slot++)
                 );
-                slot++;
-
-                if (length < 32) {
-                    value = bytes.concat(
-                        value,
-                        sliceBytes(
-                            abi.encode(storageProofs[proofIdx++].proof.value),
-                            0,
-                            length
-                        )
-                    );
-
-                    length = 0;
-                } else {
-                    value = bytes.concat(
-                        value,
-                        storageProofs[proofIdx++].proof.value
-                    );
-
-                    length -= 32;
+                off += 32;
+                bytes32 temp = storageProofs[proofIdx++].proof.value;
+                assembly {
+                    mstore(add(value, off), temp)
                 }
             }
             return (value, proofIdx);
         } else {
-            uint256 length = (firstValueUint & 0xFF) / 2;
+            uint256 length = (firstValue & 0xFF) >> 1;
             return (sliceBytes(abi.encode(firstValue), 0, length), proofIdx);
         }
     }


### PR DESCRIPTION
 - Does not really optimise the while loop but I applied the [latest changes made from ENS](https://github.com/ensdomains/evmgateway/blob/c3545bafe0b7e42d67daf4698db7bca808a6d6ac/evm-verifier/contracts/EVMProofHelper.sol#L86)
 This makes the code closer to their implementation.

- As already discussed, we won't limit the L2 value's length to fetch since it's the user that decides how much he's willing to pay to resolve that value (If the `resolve` function is involved in a transaction)