### PR TITLE
Remove invalid require condition in LineaSparseProofVerifier.sol

### DIFF
--- a/packages/linea-state-verifier/contracts/LineaSparseProofVerifier.sol
+++ b/packages/linea-state-verifier/contracts/LineaSparseProofVerifier.sol
@@ -40,8 +40,7 @@ contract LineaSparseProofVerifier is IEVMVerifier {
         // Check that the L2 block number used is a recent one and is part of the range accepted
         uint256 currentL2BlockNumber = IRollup(_rollup).currentL2BlockNumber();
         require(
-            (currentL2BlockNumber <= acceptedL2BlockRangeLength &&
-                blockNo <= currentL2BlockNumber) ||
+            (blockNo <= currentL2BlockNumber) &&
                 (blockNo >= currentL2BlockNumber - acceptedL2BlockRangeLength),
             "LineaSparseProofVerifier: block not in range accepted"
         );


### PR DESCRIPTION
https://github.com/Consensys/linea-ens/blob/1da40ef3b757b708bf2054954b36cf94cbc66266/packages/linea-state-verifier/contracts/LineaSparseProofVerifier.sol#L43

The above require condition is invalid. In the context of the `L1Resolver` the `acceptedL2BlockRangeLength` is set to 86400 (1 day) - https://github.com/Consensys/linea-ens/blob/d139c5ce34630ee383152ef977539a099300a996/packages/linea-ens-resolver/contracts/L1Resolver.sol#L42

The check is against a block number and noting the `currentL2BlockNumber` (7581832) in the Linea rollup contract (https://etherscan.io/address/0xd19d4B5d358258f05D7B411E21A1460D11B0876F#readProxyContract) this check will always evaluate to `false`.

--- 

fixes https://github.com/Consensys/linea-ens/issues/227