### PR TITLE
Fix typos in documentation

### DIFF
--- a/packages/linea-ens-app/README.md
+++ b/packages/linea-ens-app/README.md
@@ -116,7 +116,7 @@ You'll need an account with POH to fully use the local env, if you don't, you ca
   | Chain ID        | 1337                  |
   | Currency symbol | ETH                   |
 
-  - Save and Swith to `Localhost 8455`.
+  - Save and Switch to `Localhost 8455`.
 - Transfer 1 ETH from the test account above (eg: `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`), to your POH account
   - If you don't have an address with PoH, see [Common Errors](#common-errors).
 - You can start testing the app and register a domain.
@@ -267,7 +267,7 @@ To fix it, you can safely remove `data` in `./packages/linea-ens-app/data`.
 
 ### Linea PoH Status: INVALID
 
-If your address doesn't have a PoH, for testing purpose you can temporally deactivate the PoH verification:
+If your address doesn't have a PoH, for testing purpose you can temporarily deactivate the PoH verification:
 
 1. Edit `linea-ens/packages/poh-signer-api/src/modules/poh/poh.service.ts`.
 

--- a/packages/linea-ens-contracts/README.md
+++ b/packages/linea-ens-contracts/README.md
@@ -77,9 +77,9 @@ PohRegistrationManger is the contract responsible to keep track of the users tha
 
 ### PohVerifier
 
-PohVerifier is the contract responsible for checking the signature of the private key responsible for aknowledging an address has passed the POH process or not.
+PohVerifier is the contract responsible for checking the signature of the private key responsible for acknowledging an address has passed the POH process or not.
 
-- The owner of PohVerifier can set the signer address responsible for aknowledging a POH
+- The owner of PohVerifier can set the signer address responsible for acknowledging a POH
 
 ### FixedPriceOracle
 


### PR DESCRIPTION


## Changes Made

### packages/linea-ens-app/README.md
- "Swith" -> "Switch" in localhost config
- "temporally" -> "temporarily" in PoH verification section

### packages/linea-ens-contracts/README.md
- Fixed spelling of "acknowledging" in two places:
  - PohVerifier contract description
  - PohVerifier owner permissions section

These fixes make the documentation clearer and more professional.
