### PR TITLE
chore: Add code owners to the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Consensys/linea-contract-team


### PR DESCRIPTION
Add the Linea Contract team as code owners of the repo