### PR TITLE
chore: Improve GitHub pipelines

### DIFF
--- a/.github/workflows/linea-ccip-gateway-build-publish.yml
+++ b/.github/workflows/linea-ccip-gateway-build-publish.yml
@@ -5,11 +5,7 @@ on:
       - main
     paths:
       - "packages/linea-ccip-gateway/**"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "packages/linea-ccip-gateway/**"
+      - ".github/workflows/linea-ccip-gateway-build-publish.yml"
   release:
     types:
       - released

--- a/.github/workflows/linea-ccip-gateway-tests.yml
+++ b/.github/workflows/linea-ccip-gateway-tests.yml
@@ -6,6 +6,13 @@ on:
       - main
     paths:
       - "packages/linea-ccip-gateway/**"
+      - ".github/workflows/linea-ccip-gateway-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/linea-ccip-gateway/**"
+      - ".github/workflows/linea-ccip-gateway-tests.yml"
 
 jobs:
   linea-ccip-gateway-tests:

--- a/.github/workflows/linea-ens-app-build-publish.yml
+++ b/.github/workflows/linea-ens-app-build-publish.yml
@@ -6,11 +6,7 @@ on:
       - main
     paths:
       - "packages/linea-ens-app/**"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "packages/linea-ens-app/**"
+      - ".github/workflows/linea-ens-app-build-publish.yml"
   release:
     types:
       - released

--- a/.github/workflows/linea-ens-contracts-tests.yml
+++ b/.github/workflows/linea-ens-contracts-tests.yml
@@ -6,6 +6,13 @@ on:
       - main
     paths:
       - "packages/linea-ens-contracts/**"
+      - ".github/workflows/linea-ens-contracts-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/linea-ens-contracts/**"
+      - ".github/workflows/linea-ens-contracts-tests.yml"
 
 jobs:
   linea-ens-contracts-tests:

--- a/.github/workflows/linea-ens-resolver-tests.yml
+++ b/.github/workflows/linea-ens-resolver-tests.yml
@@ -6,6 +6,11 @@ on:
       - main
     paths:
       - "packages/linea-ens-resolver/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/linea-ens-app/**"
 
 jobs:
   linea-ens-resolver-tests:

--- a/.github/workflows/poh-signer-api-build-publish.yml
+++ b/.github/workflows/poh-signer-api-build-publish.yml
@@ -6,11 +6,7 @@ on:
       - main
     paths:
       - "packages/poh-signer-api/**"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "packages/poh-signer-api/**"
+      - ".github/workflows/poh-signer-api-build-publish.yml"
   release:
     types:
       - released

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# IntelliJ
+# IDE
 .idea
+.vscode
+
 node_modules
 
 # hardhat

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
- "cSpell.words": [
-  "Linea"
- ]
-}

--- a/packages/poh-signer-api/.env.example
+++ b/packages/poh-signer-api/.env.example
@@ -6,7 +6,7 @@ PORT=4000
 VERIFIER_CONTRACT_ADDRESS=0x677df0cb865368207999F2862Ece576dC56D8dF6
 
 # Poh API
-POH_API_URL=https://linea-xp-poh-api.linea.build
+POH_API_URL=http://linea-poh-api-generic-app
 
 # Web3Signer
 WEB3SIGNER_BASE_URL=http://localhost:9000

--- a/packages/poh-signer-api/.env.mainnet
+++ b/packages/poh-signer-api/.env.mainnet
@@ -6,7 +6,7 @@ PORT=3000
 VERIFIER_CONTRACT_ADDRESS=0xBf14cFAFD7B83f6de881ae6dc10796ddD7220831
 
 # Poh API
-POH_API_URL=https://linea-xp-poh-api.linea.build
+POH_API_URL=http://linea-poh-api-generic-app
 
 CHAIN_ID=59144
 

--- a/packages/poh-signer-api/.env.sepolia
+++ b/packages/poh-signer-api/.env.sepolia
@@ -6,7 +6,7 @@ PORT=3000
 VERIFIER_CONTRACT_ADDRESS=0x576754D133C02B2E229F2630Baa2F06110cE9a9A
 
 # Poh API
-POH_API_URL=https://linea-xp-poh-api.sepolia.linea.build
+POH_API_URL=http://linea-poh-api-generic-app
 
 CHAIN_ID=59141
 

--- a/packages/poh-signer-api/package.json
+++ b/packages/poh-signer-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poh-signer-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "API to get a signature for an address that has a POH",
   "author": "Consensys",
   "private": true,


### PR DESCRIPTION
1. Stop triggering Docker image build on PRs
2. Calls from the POH Signer API to the native POH API internally to the cluster