### PR TITLE
Fix Spelling, Grammar, and Formatting Issues in Contracts and Documentation

### DIFF
--- a/packages/linea-ens-contracts/contracts/resolvers/Multicallable.sol
+++ b/packages/linea-ens-contracts/contracts/resolvers/Multicallable.sol
@@ -28,7 +28,7 @@ abstract contract Multicallable is IMulticallable, ERC165 {
     }
 
     // This function provides an extra security check when called
-    // from priviledged contracts (such as EthRegistrarController)
+    // from privileged contracts (such as EthRegistrarController)
     // that can set records on behalf of the node owners
     function multicallWithNodeCheck(
         bytes32 nodehash,

--- a/packages/linea-ens-contracts/contracts/resolvers/PublicResolver.sol
+++ b/packages/linea-ens-contracts/contracts/resolvers/PublicResolver.sol
@@ -103,7 +103,7 @@ contract PublicResolver is
     }
 
     /**
-     * @dev Approve a delegate to be able to updated records on a node.
+     * @dev Approve a delegate to be able to update records on a node.
      */
     function approve(bytes32 node, address delegate, bool approved) external {
         require(msg.sender != delegate, "Setting delegate status for self");

--- a/packages/linea-ens-subgraph/README.md
+++ b/packages/linea-ens-subgraph/README.md
@@ -4,7 +4,7 @@ This Subgraph sources events from the Linea ENS contracts. This includes the ENS
 
 # Example Queries
 
-Here we have example queries, so that you don't have to type them in yourself eachtime in the graphiql playground:
+Here we have example queries, so that you don't have to type them in yourself each time in the graphiql playground:
 
 ```graphql
 {


### PR DESCRIPTION
1. Spelling Correction:
Old: priviledged
New: privileged
File: Multicallable.sol
Reason: Fixed a common misspelling of "privileged".
2. Grammar Fix in Function Comment:
Old: updated
New: update
File: PublicResolver.sol
Reason: Corrected the verb tense to match the infinitive form "update."
3. Spacing Issue Fix:
Old: eachtime
New: each time
File: README.md
Reason: Corrected the compound word to the proper form "each time."
