### PR TITLE
fix(ccip-gateway): Fix provable block reliability

### DIFF
--- a/packages/linea-ccip-gateway/src/L2ProofService.ts
+++ b/packages/linea-ccip-gateway/src/L2ProofService.ts
@@ -44,7 +44,7 @@ export class L2ProofService implements IProofService<L2ProvableBlock> {
 
   /**
    * @dev Returns the latest finalized L2 block that can be proven on L1.
-   * Applies a buffer to ensure the block's state is fully anchored and available.
+   * Applies a buffer to ensure the block's state is fully synchronized and available.
    *
    * @returns The L2 block number that is safe to use for proof submission.
    */

--- a/packages/linea-ccip-gateway/src/L2ProofService.ts
+++ b/packages/linea-ccip-gateway/src/L2ProofService.ts
@@ -63,7 +63,7 @@ export class L2ProofService implements IProofService<L2ProvableBlock> {
     }
 
     const lastBlockFinalized = await this.rollup.currentL2BlockNumber({
-      blockTag: block.number - BLOCK_BUFFER,
+      blockTag: block.number - BLOCK_SYNCHRONIZATION_BUFFER,
     });
 
     if (!lastBlockFinalized) {

--- a/packages/linea-ccip-gateway/src/L2ProofService.ts
+++ b/packages/linea-ccip-gateway/src/L2ProofService.ts
@@ -11,7 +11,7 @@ import { logDebug, logError } from './utils';
 export type L2ProvableBlock = number;
 
 const FINALIZED_TAG = 'finalized';
-const BLOCK_BUFFER = 3;
+const BLOCK_SYNCHRONIZATION_BUFFER = 3;
 const currentL2BlockNumberSig =
   'function currentL2BlockNumber() view returns (uint256)';
 


### PR DESCRIPTION
This PR applies a buffer to ensure the block's state is fully anchored and available before fetching proofs.