### PR TITLE
fix(ccip-gateway): Disable Ethers provider cache to allow parallel linea_getProof requests

### DIFF
--- a/packages/linea-ccip-gateway/src/server.ts
+++ b/packages/linea-ccip-gateway/src/server.ts
@@ -39,6 +39,10 @@ function createFallbackProvider(
     {
       provider: new JsonRpcProvider(primaryUrl, chainId, {
         staticNetwork: true,
+        batchMaxCount: 1,
+        cacheTimeout: -1,
+        polling: false,
+        batchStallTime: 0,
       }),
       polling: false,
       stallTimeout: PRIMARY_PROVIDER_TIMEOUT,
@@ -51,6 +55,10 @@ function createFallbackProvider(
     providers.push({
       provider: new JsonRpcProvider(fallbackUrl, chainId, {
         staticNetwork: true,
+        batchMaxCount: 1,
+        cacheTimeout: -1,
+        polling: false,
+        batchStallTime: 0,
       }),
       polling: false,
       stallTimeout: FALLBACK_PROVIDER_TIMEOUT,


### PR DESCRIPTION
When an Ethers provider receives multiple calls in a short period of time, it uses caching and batching to optimise performance.
However, this behaviour does not work with custom RPC methods like `linea_getProof`.

This PR disables Ethers’ caching and batching, making `linea_getProof` calls more reliable under heavy load.