### PR TITLE
fix: url hash sanitization

### DIFF
--- a/packages/linea-ens-app/src/routes.ts
+++ b/packages/linea-ens-app/src/routes.ts
@@ -247,7 +247,7 @@ export const getDestination = (url: UrlObject | string) => {
       const values = href.split('/')
       let replacedDestination = (isIPFS ? rewrite.destination : rewrite.flattenedDestination)
         .replace(/\$(\d)/g, (_, n) => values[parseInt(n)])
-        .replace('#', '%23')
+        .replace(/#/g, '%23')
       if (!isIPFS && rewrite.tldPrefix && !replacedDestination.includes('.')) {
         replacedDestination = `/tld${replacedDestination}`
       }


### PR DESCRIPTION
## Summary

  - Fix CodeQL alert js/incomplete-sanitization in URL hash encoding
  - Change .replace('#', '%23') to .replace(/#/g, '%23') to encode all hash characters, not just the first occurrence
  - Addresses routing correctness issue where multiple hash characters could result in malformed destination paths

##  Test plan

  - Verify existing routing functionality still works
  - Test URLs with multiple hash characters are properly encoded
  - Confirm CodeQL alert is resolved