### PR TITLE
Potential fix for code scanning alert no. 210: Server-side request forgery

### DIFF
--- a/packages/poh-signer-api/src/modules/poh/poh.controller.ts
+++ b/packages/poh-signer-api/src/modules/poh/poh.controller.ts
@@ -9,7 +9,7 @@ import {
 import { ApiTags } from '@nestjs/swagger';
 
 import { PohService } from './poh.service';
-import { Address } from 'viem';
+import { Address, isAddress } from 'viem';
 
 @ApiTags('PoH')
 @Controller('poh')
@@ -20,6 +20,10 @@ export class PohController {
 
   @Get(':address')
   async signMessage(@Param('address') address: Address): Promise<string> {
+    if (!isAddress(address)) {
+      this.logger.warn(`Invalid Ethereum address received: ${address}`);
+      throw new HttpException('Invalid Ethereum address', HttpStatus.BAD_REQUEST);
+    }
     try {
       return await this.pohService.signMessage(address);
     } catch (error) {
@@ -30,6 +34,10 @@ export class PohController {
 
   @Get('v2/:address')
   async signMessageV2(@Param('address') address: Address): Promise<string> {
+    if (!isAddress(address)) {
+      this.logger.warn(`Invalid Ethereum address received: ${address}`);
+      throw new HttpException('Invalid Ethereum address', HttpStatus.BAD_REQUEST);
+    }
     try {
       return await this.pohService.signMessage(address, true);
     } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/Consensys/linea-ens/security/code-scanning/210](https://github.com/Consensys/linea-ens/security/code-scanning/210)

**General fix:**  
Validate the `address` parameter to ensure it is a legitimate Ethereum address before using it to construct the URL path for the outgoing Axios request. Only allow address values that match the standard Ethereum address format (a 0x-prefixed hex string of 42 characters, with optional case insensitivity).

**Detailed approach:**  
- Before passing `address` from the controller into the service (or as soon as possible in the handling flow), check that it strictly matches a valid Ethereum address format, e.g. using a regular expression, or a helper utility from Ethereum/viem libraries. Reject or sanitize the input if it fails the check.
- Implement this validation in `PohController` for both `signMessage` and `signMessageV2` endpoints (i.e. before calling the service).
- This prevents any tainted/malicious value for `address` from reaching the URL construction in `ApiService`.

**Required methods/imports:**  
- Add an import for a standard Ethereum address validation utility, such as `isAddress` from `viem` (if available), or define a suitable regex check.
- Add the validation logic at the top of both controller endpoint handlers; if invalid, return an error.
- No changes needed in `api.service.ts`—all tainted input will be addressed at controller level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `isAddress` validation to `signMessage` and `signMessageV2`, logging a warning and returning 400 for invalid addresses.
> 
> - **Backend**
>   - **Input validation in `packages/poh-signer-api/src/modules/poh/poh.controller.ts`**:
>     - Import `isAddress` from `viem`.
>     - Validate `address` in `signMessage` and `signMessageV2`; on invalid input, log a warning and throw `HttpException(HttpStatus.BAD_REQUEST)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2af8f66677da3344cf81e0399aee274cacf12af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->