### PR TITLE
chore(linea-ens-app): update POH Signer API URL

### DIFF
--- a/packages/linea-ens-app/src/constants/chains.ts
+++ b/packages/linea-ens-app/src/constants/chains.ts
@@ -80,7 +80,7 @@ export const lineaSepoliaWithEns = addCustomEnsContracts(
   lineaSepoliaEnsAddresses,
   `https://gateway-arbitrum.network.thegraph.com/api/${process.env.NEXT_PUBLIC_THE_GRAPH_SEPOLIA_API_KEY}/subgraphs/id/6Jjkuneo5SgozoKAzi5bu2pDSHr614iQKumbRAYr8bgh`,
   'linea-sepolia',
-  'https://linea-poh-signer-api.sepolia.linea.build',
+  'https://poh-signer-api.sepolia.linea.build',
 )
 
 export const lineaMainnetWithEns = addCustomEnsContracts(
@@ -88,7 +88,7 @@ export const lineaMainnetWithEns = addCustomEnsContracts(
   lineaMainnetEnsAddresses,
   `https://gateway-arbitrum.network.thegraph.com/api/${process.env.NEXT_PUBLIC_THE_GRAPH_MAINNET_API_KEY}/subgraphs/id/G5YH6BWrybbfua5sngRQ7Ku1LRCVx4qf5zjkqWG9FSuV`,
   'linea',
-  'https://linea-poh-signer-api.linea.build',
+  'https://poh-signer-api.linea.build',
 )
 
 export const chainsWithEns = [lineaMainnetWithEns, lineaSepoliaWithEns, localhostWithEns] as const

--- a/packages/linea-ens-app/src/hooks/usePohStatus.ts
+++ b/packages/linea-ens-app/src/hooks/usePohStatus.ts
@@ -8,7 +8,7 @@ export const usePohSignature = (address: Address | undefined): Hex | undefined =
   useMemo(async () => {
     const pohSignatureApi = chain ? chain.custom.pohVerifierUrl : undefined
     if (!pohSignatureApi) return undefined
-    const resp = await fetch(`${pohSignatureApi}/poh/${address}`, {
+    const resp = await fetch(`${pohSignatureApi}/poh/v2/${address}`, {
       method: 'GET',
       redirect: 'follow',
     })

--- a/packages/poh-signer-api/README.md
+++ b/packages/poh-signer-api/README.md
@@ -1,9 +1,10 @@
 # Linea POH signer API
 
 A NestJS API responsible for returning a signature acknowledging an address has passed the POH process.  
-Uses the [POH api](https://linea-xp-poh-api.linea.build) to check if an address has a POH.
+Uses the [POH api](https://poh-api.linea.build) to check if an address has a POH.
 
-POH stands for Proof Of Humanity, it respects a set of rules that determines if an address is human or not, a user has to go through a POH process to be marked as POH.
+POH stands for Proof Of Humanity, it respects a set of rules that determines if an address is human or not, a user has
+to go through a POH process to be marked as POH.
 
 ## Installation
 


### PR DESCRIPTION
#339 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Point POH signer API to new domain for mainnet/sepolia and switch hook to `/poh/v2`; update README POH API URL.
> 
> - **Linea ENS App**:
>   - **API Domains**: Update `pohVerifierUrl` to `https://poh-signer-api.*.linea.build` in `src/constants/chains.ts` for `linea` and `linea-sepolia`.
>   - **Hook Endpoint**: Change fetch path in `src/hooks/usePohStatus.ts` from `/poh/{address}` to `/poh/v2/{address}`.
> - **Docs**:
>   - **POH API URL**: Update README link to `https://poh-api.linea.build` in `packages/poh-signer-api/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb47c686a125e96c629831433fdac022af2caa50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->