### PR TITLE
fix(poh-signer-api): SSL connection to Web3Signer

### DIFF
--- a/packages/poh-signer-api/src/modules/signer/signer.service.ts
+++ b/packages/poh-signer-api/src/modules/signer/signer.service.ts
@@ -176,7 +176,6 @@ export class SignerService {
       pfx: clientPfx,
       passphrase: keystorePassphrase,
       ca: caCertPem,
-      rejectUnauthorized: true,
       requestCert: true,
     });
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `rejectUnauthorized` from the HTTPS `Agent` options used to call Web3Signer.
> 
> - **Backend**
>   - **HTTPS Agent Configuration**: Remove `rejectUnauthorized` from `createWeb3SignerHttpsAgent` in `packages/poh-signer-api/src/modules/signer/signer.service.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d46e8a1b02d582fd4ee5bc2d132cc28824986714. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->