### PR TITLE
chore(pnpm-workspace): add minimumReleaseAge configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 4320 # 3 days
+
 packages:
   - packages/linea-state-verifier
   - packages/linea-ccip-gateway


### PR DESCRIPTION
Add `minimumReleaseAge` to 3 days.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `minimumReleaseAge` to 3 days in `pnpm-workspace.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb7121ac259abb556c242f097846ce6de9758a59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->