### PR TITLE
fix(linea-ens-app): failing build process

### DIFF
--- a/packages/linea-ens-app/README.md
+++ b/packages/linea-ens-app/README.md
@@ -101,8 +101,8 @@ cd packages/linea-ens-app
 pnpm dev:glocal
 ```
 
-You'll need an account with POH to fully use the local env, if you don't, you can get
-it [here] (https://poh.linea.build/).
+You'll need an account with POH to fully use the local env, if you don't, you can get it
+via [Linea Hub] (https://linea.build/hub/).
 
 - Then browse http://localhost:3000/.
 - Import one of the hardhat test accounts in your MetaMask to have funds (eg, private key:
@@ -114,7 +114,7 @@ it [here] (https://poh.linea.build/).
     - Add this config:
 
   | Setting         | Value                 |
-  | --------------- | --------------------- |
+    | --------------- | --------------------- |
   | Network name    | Localhost 8545        |
   | New RPC URL     | http://127.0.0.1:8545 |
   | Chain ID        | 1337                  |

--- a/packages/linea-ens-app/next-env.d.ts
+++ b/packages/linea-ens-app/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/linea-ens-app/src/components/pages/profile/[name]/registration/steps/PohCheck/PohCheck.tsx
+++ b/packages/linea-ens-app/src/components/pages/profile/[name]/registration/steps/PohCheck/PohCheck.tsx
@@ -87,7 +87,7 @@ export const ActionButton = ({
     return (
       <Button
         data-testid="next-button"
-        onClick={() => window.open('https://poh.linea.build/', '_blank')}
+        onClick={() => window.open('https://linea.build/hub/', '_blank')}
       >
         {t('steps.pohCheck.getPoh')}
       </Button>

--- a/packages/linea-ens-app/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/ExpirySection.test.tsx
+++ b/packages/linea-ens-app/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/ExpirySection.test.tsx
@@ -26,13 +26,6 @@ vi.mock('./hooks/useExpiryActions', () => ({
     if (name === 'test.eth')
       return [
         {
-          label: 'action.setReminder',
-          type: 'set-reminder',
-          icon: <div>ICON</div>,
-          primary: false,
-          expiryDate: new Date(),
-        },
-        {
           label: 'action.extend',
           type: 'extend',
           icon: <div>ICON</div>,
@@ -46,20 +39,6 @@ vi.mock('./hooks/useExpiryActions', () => ({
 }))
 
 describe('ExpirySection', () => {
-  it('should be able to open earnify button modal', async () => {
-    render(<ExpirySection name="test.eth" details={{} as any} />)
-    expect(screen.getByText('action.setReminder')).toBeVisible()
-    expect(screen.getByText('action.extend')).toBeVisible()
-    await userEvent.click(screen.getByText('action.setReminder'))
-    await waitFor(async () => {
-      expect(screen.getByText('tabs.more.misc.reminderOptions.bankless')).toBeVisible()
-      await userEvent.click(screen.getByText('tabs.more.misc.reminderOptions.bankless'))
-    })
-    await waitFor(() => {
-      expect(screen.getByText('tabs.more.misc.bankless.title')).toBeVisible()
-    })
-  })
-
   it('should be able to call show extend modal', async () => {
     render(<ExpirySection name="test.eth" details={{} as any} />)
     expect(screen.getByText('action.extend')).toBeVisible()

--- a/packages/linea-ens-app/tsconfig.json
+++ b/packages/linea-ens-app/tsconfig.json
@@ -59,11 +59,11 @@
     "**/*.ts",
     "**/*.tsx",
     "next.config.mjs",
-    "vitest.config.mts",
     "test/*.mts",
     "test/**/*.ts",
     "typings-custom/generated/*.d.ts",
-    "typings-custom/local-contracts.d.ts"
+    "typings-custom/local-contracts.d.ts",
+    "typings-custom/**/*.d.ts"
   ],
   "exclude": [
     "**/*.ignore.ts",

--- a/packages/linea-ens-app/typings-custom/react-confetti.d.ts
+++ b/packages/linea-ens-app/typings-custom/react-confetti.d.ts
@@ -1,0 +1,117 @@
+declare module 'react-confetti' {
+  import { CSSProperties, RefObject } from 'react'
+
+  export interface IConfettiOptions {
+    /**
+     * Width of the canvas element
+     */
+    width?: number
+    /**
+     * Height of the canvas element
+     */
+    height?: number
+    /**
+     * Number of confetti pieces to render
+     * @default 200
+     */
+    numberOfPieces?: number
+    /**
+     * Slows movement of pieces (lower number is faster)
+     * @default 5000
+     */
+    friction?: number
+    /**
+     * Force of "wind" on pieces
+     * @default 0
+     */
+    wind?: number
+    /**
+     * Force of gravity on pieces
+     * @default 0.1
+     */
+    gravity?: number
+    /**
+     * Initial velocity in the X axis
+     * @default 4
+     */
+    initialVelocityX?: { min: number; max: number } | number
+    /**
+     * Initial velocity in the Y axis
+     * @default 10
+     */
+    initialVelocityY?: { min: number; max: number } | number
+    /**
+     * Shape of confetti.
+     * @default 'All'
+     */
+    pieceShape?: 'Circle' | 'Square' | 'Strip' | 'All'
+    /**
+     * Width of confetti pieces
+     * @default { min: 5, max: 20 }
+     */
+    pieceWidth?: {
+      min: number
+      max: number
+    } | number
+    /**
+     * Height of confetti pieces
+     * @default { min: 5, max: 20 }
+     */
+    pieceHeight?: {
+      min: number
+      max: number
+    } | number
+    /**
+     * Array of colors to choose from.
+     */
+    colors?: string[]
+    /**
+     * Opacity of the confetti pieces
+     * @default 1.0
+     */
+    opacity?: number
+    /**
+     * Whether to recycle confetti pieces (animation will repeat)
+     * @default true
+     */
+    recycle?: boolean
+    /**
+     * Run the animation
+     * @default true
+     */
+    run?: boolean
+    /**
+     * Show debugging information for tweaking config
+     * @default false
+     */
+    debug?: boolean
+    /**
+     * Canvas style properties
+     */
+    style?: CSSProperties
+    /**
+     * Canvas className
+     */
+    className?: string
+    /**
+     * Manually set a reference to the canvas element
+     */
+    canvasRef?: RefObject<HTMLCanvasElement> | ((instance: HTMLCanvasElement | null) => void) | null
+    /**
+     * Callback when animation is complete (when recycle is false)
+     */
+    onConfettiComplete?: (confetti?: any) => void
+    /**
+     * Additional canvas properties
+     */
+    drawShape?: (context: CanvasRenderingContext2D) => void
+    /**
+     * Tweens for controlling the animation
+     */
+    tweenDuration?: number
+    tweenFunction?: (currentTime: number, startValue: number, changeInValue: number, duration: number) => number
+  }
+
+  export default function Confetti(props: IConfettiOptions): JSX.Element
+}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes build by adjusting TypeScript config and adding missing type declarations, updates PoH links to Linea Hub, and removes an obsolete reminder test.
> 
> - **Build/TypeScript**:
>   - Remove `/// <reference path="./.next/types/routes.d.ts" />` from `next-env.d.ts`.
>   - Update `tsconfig.json` includes: drop `vitest.config.mts`; add `typings-custom/**/*.d.ts`.
>   - Add custom typings `typings-custom/react-confetti.d.ts`.
> - **Frontend**:
>   - Update PoH acquisition link to Linea Hub in `README.md` and `PohCheck.tsx` action button (`https://linea.build/hub/`).
> - **Tests**:
>   - Remove reminder-related action and modal test from `ExpirySection.test.tsx`; keep extend action test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02133ec7043cd9aed68d2c03a39c198f899be9ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->